### PR TITLE
Fixed the VM Configuration Specified

### DIFF
--- a/Lab 4/docs/conf.py
+++ b/Lab 4/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'Docker ARP Analysis Documentation'
 copyright = '2024, Charles Uneze'
 author = 'Charles Uneze'
-release = 'v0.1'
+release = 'v0.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/Lab 4/docs/pages/requirements.rst
+++ b/Lab 4/docs/pages/requirements.rst
@@ -38,7 +38,7 @@ Simple and fast, right?
 .. code-block:: bash
 
    # Terminal-1 Mac/Linux
-   multipass launch jammy --name=ubuntu --cpus=4 --disk=20G --memory=8G
+   multipass launch jammy --name=ubuntu --cpus=1 --disk=8G --memory=1G
 
 jammy is the image `name <https://multipass.run/docs/create-an-instance#heading--create-an-instance-with-a-specific-image>`_ for Ubuntu server version 22.04.
 


### PR DESCRIPTION
# Previous Sentence
`multipass launch jammy --name=ubuntu --cpus=4 --disk=20G --memory=8G`

# New Sentence
`multipass launch jammy --name=ubuntu --cpus=1 --disk=8G --memory=1G`

# Issue
The previous sentence used the wrong VM specification.

# Conclusion
The new sentence properly specified the requirements in the documentation.